### PR TITLE
In addition to default browser specific autocomplete "off" values:

### DIFF
--- a/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/AutocompleteOffExtension.java
+++ b/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/AutocompleteOffExtension.java
@@ -1,5 +1,6 @@
 package com.vaadin.addons;
 
+import com.vaadin.addons.client.AutocompleteOffExtensionState;
 import com.vaadin.server.AbstractExtension;
 import com.vaadin.ui.AbstractField;
 
@@ -14,5 +15,38 @@ public class AutocompleteOffExtension extends AbstractExtension {
     public static void setAutocompleteOff(AbstractField<?> field) {
         AutocompleteOffExtension ex = new AutocompleteOffExtension();
         ex.extend(field);
+    }
+
+    /**
+     * Set autocomplete attribute off for input field component with
+     * random number autocomplete attribute value
+     *
+     * @param field
+     *            component extending AbstractField
+     */
+    public static void setAutocompleteOffWithRandomNumber(AbstractField<?> field) {
+        AutocompleteOffExtension ex = new AutocompleteOffExtension();
+        ex.getState().useRandomNumber = true;
+        ex.extend(field);
+    }
+
+    /**
+     * Set autocomplete attribute off for input field component with
+     * given value for autocomplete attribute
+     *
+     * @param field
+     *            component extending AbstractField
+     * @param attributeValue
+     *            a value for field's autocomplete attribute
+     */
+    public static void setAutocompleteOffWithManualValue(AbstractField<?> field, String attributeValue) {
+        AutocompleteOffExtension ex = new AutocompleteOffExtension();
+        ex.getState().attributeValue = attributeValue;
+        ex.extend(field);
+    }
+
+    @Override
+    protected AutocompleteOffExtensionState getState() {
+        return (AutocompleteOffExtensionState) super.getState();
     }
 }

--- a/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/client/AutocompleteOffExtensionConnector.java
+++ b/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/client/AutocompleteOffExtensionConnector.java
@@ -24,7 +24,16 @@ public class AutocompleteOffExtensionConnector
         if (target instanceof AbstractDateFieldConnector) {
             VDateField field;
             field = ((AbstractDateFieldConnector) target).getWidget();
-            if (BrowserInfo.get().isChrome()) {
+
+            if (getState().useRandomNumber) {
+                field.getElement().getFirstChildElement()
+                        .setAttribute("autocomplete", Math.random() + "");
+            } else if (getState().attributeValue!=null) {
+                field.getElement().getFirstChildElement()
+                        .setAttribute("autocomplete",
+                                getState().attributeValue);
+            }
+            else if (BrowserInfo.get().isChrome()) {
                 field.getElement().getFirstChildElement()
                         .setAttribute("autocomplete", "off");
             } else {
@@ -35,7 +44,14 @@ public class AutocompleteOffExtensionConnector
             Widget field;
             field = ((AbstractFieldConnector) target).getWidget();
 
-            if (BrowserInfo.get().isChrome()) {
+            if (getState().useRandomNumber) {
+                field.getElement().setAttribute("autocomplete",
+                        Math.random() + "");
+            } else if (getState().attributeValue!=null) {
+                field.getElement().setAttribute("autocomplete",
+                        getState().attributeValue);
+            }
+            else if (BrowserInfo.get().isChrome()) {
                 field.getElement().setAttribute("autocomplete", "off");
             } else {
                 field.getElement().setAttribute("autocomplete",
@@ -45,4 +61,8 @@ public class AutocompleteOffExtensionConnector
 
     }
 
+    @Override
+    public AutocompleteOffExtensionState getState() {
+        return (AutocompleteOffExtensionState)super.getState();
+    }
 }

--- a/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/client/AutocompleteOffExtensionState.java
+++ b/autocomplete-off-extension-addon/src/main/java/com/vaadin/addons/client/AutocompleteOffExtensionState.java
@@ -1,0 +1,10 @@
+package com.vaadin.addons.client;
+
+import com.vaadin.shared.communication.SharedState;
+
+public class AutocompleteOffExtensionState extends SharedState {
+
+    public boolean useRandomNumber = false;
+    public String attributeValue = null;
+
+}

--- a/autocomplete-off-extension-demo/src/main/java/com/vaadin/addons/demo/DemoUI.java
+++ b/autocomplete-off-extension-demo/src/main/java/com/vaadin/addons/demo/DemoUI.java
@@ -19,11 +19,7 @@ import com.vaadin.data.validator.DateRangeValidator;
 import com.vaadin.data.validator.StringLengthValidator;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinServlet;
-import com.vaadin.ui.DateField;
-import com.vaadin.ui.FormLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.TextField;
-import com.vaadin.ui.UI;
+import com.vaadin.ui.*;
 
 @Theme("demo")
 @Title("AutocompleteOffExtension Demo")
@@ -37,6 +33,18 @@ public class DemoUI extends UI {
 
     @Override
     protected void init(VaadinRequest request) {
+        HorizontalLayout hl = new HorizontalLayout();
+        hl.setWidth("100%");
+        hl.setSpacing(true);
+
+        hl.addComponent(createFormLayout("Use default configuration", false, null));
+        hl.addComponent(createFormLayout("Random number for autocomplete attribute", true, null));
+        hl.addComponent(createFormLayout("Manual autocomplete attribute value", false, "test"));
+
+        setContent(hl);
+    }
+
+    private FormLayout createFormLayout(String caption, boolean useRandomAttributeValue, String manualAttributeValue) {
         Binder<Person> binder = new Binder<>(Person.class);
 
         TextField t1 = new TextField("Required");
@@ -49,8 +57,16 @@ public class DemoUI extends UI {
         df.setPlaceholder("Date something");
 
         // set autocomplete off attribute for t2 and df
-        AutocompleteOffExtension.setAutocompleteOff(t2);
-        AutocompleteOffExtension.setAutocompleteOff(df);
+        if (useRandomAttributeValue) {
+            AutocompleteOffExtension.setAutocompleteOffWithRandomNumber(t2);
+            AutocompleteOffExtension.setAutocompleteOffWithRandomNumber(df);
+        } else if (manualAttributeValue!=null) {
+            AutocompleteOffExtension.setAutocompleteOffWithManualValue(t2, manualAttributeValue);
+            AutocompleteOffExtension.setAutocompleteOffWithManualValue(df, manualAttributeValue);
+        } else {
+            AutocompleteOffExtension.setAutocompleteOff(t2);
+            AutocompleteOffExtension.setAutocompleteOff(df);
+        }
 
         // bind fields with validators to test nothing breaks
         binder.forField(t1).asRequired("You need to do this")
@@ -73,7 +89,7 @@ public class DemoUI extends UI {
                 .withConverter(new Converter<LocalDate, Date>() {
                     @Override
                     public Result<Date> convertToModel(LocalDate value,
-                            ValueContext context) {
+                                                       ValueContext context) {
                         Date date = Date
                                 .from(value.atStartOfDay(ZoneId.systemDefault())
                                         .toInstant());
@@ -98,10 +114,11 @@ public class DemoUI extends UI {
         binder.setBean(new Person("Lorem", "Ipsum", c.getTime()));
 
         final FormLayout layout = new FormLayout();
+        layout.setCaption(caption);
         layout.setStyleName("demoContentLayout");
         layout.setSizeFull();
         layout.addComponents(t1, t2, df, label);
-        setContent(layout);
+        return layout;
     }
 
 }


### PR DESCRIPTION
In addition to default browser specific autocomplete "off" values:
 1. allow manually enforce using random number (also with Chrome) or
 2. manual autocomplete attribute value.